### PR TITLE
Correct the spelling of CocoaPods in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # CustomizableActionSheet
 ![Platform](https://cocoapod-badges.herokuapp.com/p/CustomizableActionSheet/badge.svg)
 ![License](https://img.shields.io/cocoapods/l/CustomizableActionSheet.svg?style=flat)
-![Cocoapods](https://cocoapod-badges.herokuapp.com/v/CustomizableActionSheet/badge.svg)
+![CocoaPods](https://cocoapod-badges.herokuapp.com/v/CustomizableActionSheet/badge.svg)
 
 Action sheet allows including your custom views and buttons.
 


### PR DESCRIPTION
This pull requests corrects the spelling of **CocoaPods** 🤓
https://github.com/CocoaPods/shared_resources/tree/master/media

<blockquote class="twitter-tweet" data-lang="en"><p lang="en" dir="ltr">One day I’ll make a bot that looks through the READMEs of all Pods, looks to see if it uses “Cocoapods” and PRs “CocoaPods” :D</p>&mdash; Ørta (@orta) <a href="https://twitter.com/orta/status/697374357975388160">February 10, 2016</a></blockquote>

<script async src="//platform.twitter.com/widgets.js" charset="utf-8"></script>
