### PR TITLE
Fix animation

### DIFF
--- a/CustomizableActionSheet/CustomizableActionSheet.swift
+++ b/CustomizableActionSheet/CustomizableActionSheet.swift
@@ -196,11 +196,13 @@ public class CustomizableActionSheet: NSObject {
     }
     let positionX: CGFloat = safeAreaLeft
     var positionY: CGFloat = targetBounds.minY + targetBounds.height - currentPosition - safeAreaBottom
-    var moveY: CGFloat = positionY
+    var moveY: CGFloat = currentPosition
     if self.position == .top {
       positionY = CustomizableActionSheet.kItemInterval
       moveY = -currentPosition
     }
+    // Reset transform from dismiss() if this CustomizableActionSheet is being reused.
+    self.itemContainerView.transform = CGAffineTransform.identity
     self.itemContainerView.frame = CGRect(
       x: positionX,
       y: positionY,

--- a/Source/CustomizableActionSheet.swift
+++ b/Source/CustomizableActionSheet.swift
@@ -196,11 +196,13 @@ public class CustomizableActionSheet: NSObject {
     }
     let positionX: CGFloat = safeAreaLeft
     var positionY: CGFloat = targetBounds.minY + targetBounds.height - currentPosition - safeAreaBottom
-    var moveY: CGFloat = positionY
+    var moveY: CGFloat = currentPosition
     if self.position == .top {
       positionY = CustomizableActionSheet.kItemInterval
       moveY = -currentPosition
     }
+    // Reset transform from dismiss() if this CustomizableActionSheet is being reused.
+    self.itemContainerView.transform = CGAffineTransform.identity
     self.itemContainerView.frame = CGRect(
       x: positionX,
       y: positionY,


### PR DESCRIPTION
Hi Beryu,

I would like to propose a fix on animation. 

The problem will become more obvious, if I increase the height of custom view, and make the animation time longer. 

Here's the video before the proposed fix, and after the proposed fix.

The idea of the fix is, the _delta Y animation_ should be the _height_ of the bottom sheet, not the _y-position_ of bottom sheet

**Before**


https://user-images.githubusercontent.com/308276/104816277-14d68680-5855-11eb-947e-7b93173541f5.mov

**After**


https://user-images.githubusercontent.com/308276/104816287-291a8380-5855-11eb-9756-679ed72967a4.mov

At the same time, I am also proposing adding `self.itemContainerView.transform = CGAffineTransform.identity` before setting `frame`. This enables us to clear off the transform from `dismiss()`, if we are re-using this `CustomizableActionSheet`

Thank you very much.

